### PR TITLE
fix French example in translations slide

### DIFF
--- a/src/index.adoc
+++ b/src/index.adoc
@@ -195,7 +195,7 @@ include::{uri-script}[tag=translation-langs]
 
 [source,text]
 ----
-:appendix-caption: Appendice
+:appendix-caption: Annexe
 :appendix-refsig: {appendix-caption}
 :caution-caption: Avertissement
 :example-caption: Exemple


### PR DESCRIPTION
Appendix must translate to Annexe, not Appendice. Appendice exists but has other meanings.